### PR TITLE
feat: integrate streams, auth, and persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+POSTGRES_URL=postgresql+asyncpg://user:password@localhost:5432/angel
+REDIS_URL=redis://localhost:6379/0
+JWT_SECRET=changeme
+JWT_ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=15
+TOTP_ISSUER=ANGEL.AI

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.env
+.env.*
+node_modules/
+package-lock.json
+pytest_cache/
+!/.env.example

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,108 @@
+"""JWT authentication with optional TOTP and RBAC."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Annotated, Optional
+
+import pyotp
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .config import settings
+from .db import get_session
+from .models import User
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+
+class Token(BaseModel):
+    """JWT access token."""
+
+    access_token: str
+    token_type: str = "bearer"
+
+
+class TokenData(BaseModel):
+    """Data embedded in JWT tokens."""
+
+    username: str
+    role: str
+
+
+async def get_user(session: AsyncSession, username: str) -> Optional[User]:
+    """Retrieve a user from the database."""
+    result = await session.execute(select(User).where(User.username == username))
+    return result.scalar_one_or_none()
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a password against its hash."""
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    """Hash a password for storage."""
+    return pwd_context.hash(password)
+
+
+async def authenticate_user(session: AsyncSession, username: str, password: str, totp_code: Optional[str]) -> User:
+    """Authenticate user with password and optional TOTP."""
+    user = await get_user(session, username)
+    if not user or not verify_password(password, user.hashed_password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    if user.totp_secret:
+        if not totp_code:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="TOTP required")
+        totp = pyotp.TOTP(user.totp_secret)
+        if not totp.verify(totp_code):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid TOTP code")
+    return user
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    """Create a signed JWT token."""
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=settings.access_token_expire_minutes))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
+async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)], session: Annotated[AsyncSession, Depends(get_session)]) -> User:
+    """Decode JWT and return current user."""
+    credentials_exception = HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Could not validate credentials")
+    try:
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+        username: str = payload.get("sub")
+        role: str = payload.get("role")
+        if username is None or role is None:
+            raise credentials_exception
+    except JWTError as exc:
+        raise credentials_exception from exc
+    user = await get_user(session, username)
+    if user is None:
+        raise credentials_exception
+    return user
+
+
+def require_role(required_role: str):
+    """Dependency factory enforcing RBAC."""
+
+    async def role_checker(user: Annotated[User, Depends(get_current_user)]) -> User:
+        if user.role != required_role:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient privileges")
+        return user
+
+    return role_checker
+
+
+async def login(form_data: Annotated[OAuth2PasswordRequestForm, Depends()], session: Annotated[AsyncSession, Depends(get_session)]) -> Token:
+    """OAuth2 password flow endpoint."""
+    user = await authenticate_user(session, form_data.username, form_data.password, form_data.scopes[0] if form_data.scopes else None)
+    token = create_access_token({"sub": user.username, "role": user.role})
+    return Token(access_token=token)

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,21 @@
+"""Application configuration via environment variables."""
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field
+
+
+class Settings(BaseSettings):
+    """Strongly typed application settings."""
+
+    postgres_url: str = Field(alias="POSTGRES_URL")
+    redis_url: str = Field(alias="REDIS_URL")
+    jwt_secret: str = Field(alias="JWT_SECRET")
+    jwt_algorithm: str = Field(default="HS256", alias="JWT_ALGORITHM")
+    access_token_expire_minutes: int = Field(default=15, alias="ACCESS_TOKEN_EXPIRE_MINUTES")
+    totp_issuer: str = Field(default="ANGEL.AI", alias="TOTP_ISSUER")
+
+    model_config = SettingsConfigDict(env_file=".env", case_sensitive=True, populate_by_name=True)
+
+
+settings = Settings()

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,30 @@
+"""Database session management."""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import AsyncSessionLocal, init_db
+
+
+@asynccontextmanager
+async def session_scope() -> AsyncGenerator[AsyncSession, None]:
+    """Context manager yielding a database session."""
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    """Dependency that provides a session."""
+    async with session_scope() as session:
+        yield session
+
+
+__all__ = ["get_session", "init_db", "session_scope"]

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,75 @@
+"""SQLAlchemy ORM models for durable storage."""
+from __future__ import annotations
+
+from datetime import datetime
+from sqlalchemy import Column, DateTime, Float, Integer, String
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from .config import settings
+
+Base = declarative_base()
+
+
+class TimestampMixin:
+    """Adds creation timestamp to models."""
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class Signal(Base, TimestampMixin):
+    __tablename__ = "signals"
+    id = Column(Integer, primary_key=True)
+    symbol = Column(String(16), nullable=False)
+    direction = Column(String(4), nullable=False)
+    strength = Column(Float, nullable=False)
+
+
+class Order(Base, TimestampMixin):
+    __tablename__ = "orders"
+    id = Column(Integer, primary_key=True)
+    symbol = Column(String(16), nullable=False)
+    quantity = Column(Float, nullable=False)
+    price = Column(Float, nullable=False)
+    status = Column(String(16), nullable=False)
+
+
+class Fill(Base, TimestampMixin):
+    __tablename__ = "fills"
+    id = Column(Integer, primary_key=True)
+    order_id = Column(Integer, nullable=False)
+    quantity = Column(Float, nullable=False)
+    price = Column(Float, nullable=False)
+
+
+class RiskMetric(Base, TimestampMixin):
+    __tablename__ = "risk_metrics"
+    id = Column(Integer, primary_key=True)
+    name = Column(String(32), nullable=False)
+    value = Column(Float, nullable=False)
+
+
+class Sentiment(Base, TimestampMixin):
+    __tablename__ = "sentiment"
+    id = Column(Integer, primary_key=True)
+    source = Column(String(32), nullable=False)
+    score = Column(Float, nullable=False)
+
+
+class User(Base, TimestampMixin):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True)
+    username = Column(String(50), unique=True, nullable=False)
+    hashed_password = Column(String(128), nullable=False)
+    role = Column(String(32), nullable=False)
+    totp_secret = Column(String(32), nullable=True)
+
+
+engine = create_async_engine(settings.postgres_url, future=True, echo=False)
+AsyncSessionLocal = sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
+
+
+async def init_db() -> None:
+    """Create database tables."""
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/app/redis_streams.py
+++ b/app/redis_streams.py
@@ -1,0 +1,46 @@
+"""Redis Stream publishers and subscribers."""
+from __future__ import annotations
+
+from enum import Enum
+from typing import AsyncGenerator, Dict
+
+import redis.asyncio as aioredis
+
+from .config import settings
+
+
+class StreamChannel(str, Enum):
+    SIGNAL = "signals"
+    ORDER = "orders"
+    FILL = "fills"
+    RISK = "risk"
+    SENTIMENT = "sentiment"
+
+
+async def get_redis() -> aioredis.Redis:
+    """Create a Redis connection."""
+    return await aioredis.from_url(settings.redis_url, encoding="utf-8", decode_responses=True)
+
+
+async def publish(stream: StreamChannel, message: Dict[str, str]) -> None:
+    """Publish a message to a Redis stream."""
+    redis = await get_redis()
+    try:
+        await redis.xadd(stream.value, message)
+    finally:
+        await redis.close()
+
+
+async def subscribe(stream: StreamChannel, last_id: str = "$") -> AsyncGenerator[Dict[str, str], None]:
+    """Subscribe to a Redis stream yielding new messages."""
+    redis = await get_redis()
+    try:
+        while True:
+            response = await redis.xread({stream.value: last_id}, block=1000, count=10)
+            if response:
+                for _, messages in response:
+                    for msg_id, data in messages:
+                        last_id = msg_id
+                        yield data
+    finally:
+        await redis.close()

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -1,0 +1,41 @@
+"""APScheduler jobs for warmup, housekeeping, and backtests."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from sqlalchemy import delete
+
+from .db import get_session
+from .models import RiskMetric
+
+logger = logging.getLogger(__name__)
+
+
+async def warmup() -> None:
+    """Warmup job executed at startup."""
+    logger.info("Warmup job executed")
+
+
+async def housekeeping() -> None:
+    """Remove risk metrics older than 30 days."""
+    async with get_session() as session:
+        cutoff = datetime.utcnow() - timedelta(days=30)
+        await session.execute(delete(RiskMetric).where(RiskMetric.created_at < cutoff))
+        logger.info("Housekeeping removed old risk metrics")
+
+
+async def backtest() -> None:
+    """Run a simple backtest placeholder."""
+    logger.info("Backtest job executed")
+
+
+def start_scheduler() -> AsyncIOScheduler:
+    """Start background scheduler with configured jobs."""
+    scheduler = AsyncIOScheduler()
+    scheduler.add_job(warmup, "date")
+    scheduler.add_job(housekeeping, "cron", hour=0)
+    scheduler.add_job(backtest, "cron", hour="*/6")
+    scheduler.start()
+    return scheduler

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,35 @@
+"""Pydantic models for request validation."""
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class SignalIn(BaseModel):
+    symbol: str
+    direction: str
+    strength: float
+
+
+class OrderIn(BaseModel):
+    symbol: str
+    price: float
+    capital: float
+    win_prob: float = Field(..., ge=0, le=1)
+    win_loss_ratio: float = Field(..., gt=0)
+    var_limit: float = Field(..., gt=0)
+
+
+class FillIn(BaseModel):
+    order_id: int
+    quantity: float
+    price: float
+
+
+class RiskMetricIn(BaseModel):
+    name: str
+    value: float
+
+
+class SentimentIn(BaseModel):
+    source: str
+    score: float

--- a/app/websocket.py
+++ b/app/websocket.py
@@ -1,0 +1,23 @@
+"""WebSocket endpoints streaming Redis events to clients."""
+from __future__ import annotations
+
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from .redis_streams import StreamChannel, subscribe
+
+router = APIRouter()
+
+
+@router.websocket("/ws/{stream}")
+async def websocket_endpoint(websocket: WebSocket, stream: StreamChannel) -> None:
+    """Stream updates from Redis to the WebSocket client."""
+    await websocket.accept()
+    subscriber = subscribe(stream)
+    try:
+        async for message in subscriber:
+            await websocket.send_json(message)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        await websocket.close()

--- a/main.py
+++ b/main.py
@@ -1,22 +1,35 @@
+"""ANGEL.AI Backend application."""
+from __future__ import annotations
 
-import os, asyncpg, aioredis, logging
-from fastapi import FastAPI, Depends
+import logging
+from typing import Dict
+
+from fastapi import Depends, FastAPI, HTTPException
 from prometheus_client import Counter, Histogram, generate_latest
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import Response
 
-app = FastAPI(title="ANGEL.AI Backend", version="0.1.0")
+from app.auth import login, require_role
+from app.db import get_session, init_db
+from app.models import Fill, Order, RiskMetric, Sentiment, Signal
+from app.redis_streams import StreamChannel, publish
+from app.scheduler import start_scheduler
+from app.schemas import FillIn, OrderIn, RiskMetricIn, SentimentIn, SignalIn
+from app.websocket import router as ws_router
 
-REQUEST_TIME = Histogram('http_request_duration_seconds', 'Request latency')
-HITS = Counter('http_request_total', 'Total HTTP hits')
+logging.basicConfig(level=logging.INFO)
 
-async def get_pg():
-    url = os.getenv("POSTGRES_URL")
-    conn = await asyncpg.connect(dsn=url)
-    return conn
+app = FastAPI(title="ANGEL.AI Backend", version="0.2.0")
 
-async def get_redis():
-    url = os.getenv("REDIS_URL")
-    return await aioredis.from_url(url, encoding="utf-8", decode_responses=True)
+REQUEST_TIME = Histogram("http_request_duration_seconds", "Request latency")
+HITS = Counter("http_request_total", "Total HTTP hits")
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    await init_db()
+    start_scheduler()
+
 
 @app.middleware("http")
 async def metrics_mw(request, call_next):
@@ -24,10 +37,75 @@ async def metrics_mw(request, call_next):
     with REQUEST_TIME.time():
         return await call_next(request)
 
+
+@app.post("/auth/token")
+async def auth_token(token=Depends(login)):
+    return token
+
+
 @app.get("/health")
-async def health():
+async def health() -> Dict[str, str]:
     return {"status": "ok"}
 
+
 @app.get("/metrics")
-async def metrics():
+async def metrics() -> Response:
     return Response(generate_latest(), media_type="text/plain")
+
+
+@app.post("/signals", dependencies=[Depends(require_role("analyst"))])
+async def create_signal(payload: SignalIn, session: AsyncSession = Depends(get_session)) -> Dict[str, int]:
+    """Store and publish trading signals."""
+    signal = Signal(**payload.dict())
+    session.add(signal)
+    await session.flush()
+    await publish(StreamChannel.SIGNAL, {"id": str(signal.id), **payload.dict()})
+    return {"id": signal.id}
+
+
+@app.post("/orders", dependencies=[Depends(require_role("trader"))])
+async def create_order(payload: OrderIn, session: AsyncSession = Depends(get_session)) -> Dict[str, float]:
+    """Risk-managed order creation with Kelly sizing."""
+    kelly_fraction = payload.win_prob - (1 - payload.win_prob) / payload.win_loss_ratio
+    quantity = (payload.capital * kelly_fraction) / payload.price
+    max_risk = payload.capital * payload.var_limit
+    if quantity * payload.price > max_risk:
+        raise HTTPException(status_code=400, detail="Risk limit exceeded")
+    order = Order(symbol=payload.symbol, quantity=quantity, price=payload.price, status="NEW")
+    session.add(order)
+    await session.flush()
+    await publish(StreamChannel.ORDER, {"id": str(order.id), "symbol": payload.symbol, "quantity": f"{quantity}", "price": f"{payload.price}"})
+    return {"id": order.id, "quantity": quantity}
+
+
+@app.post("/fills", dependencies=[Depends(require_role("trader"))])
+async def create_fill(payload: FillIn, session: AsyncSession = Depends(get_session)) -> Dict[str, int]:
+    """Record fill events and publish to subscribers."""
+    fill = Fill(**payload.dict())
+    session.add(fill)
+    await session.flush()
+    await publish(StreamChannel.FILL, {"id": str(fill.id), **payload.dict()})
+    return {"id": fill.id}
+
+
+@app.post("/risk", dependencies=[Depends(require_role("risk"))])
+async def create_risk(payload: RiskMetricIn, session: AsyncSession = Depends(get_session)) -> Dict[str, int]:
+    """Persist risk metrics and publish them."""
+    metric = RiskMetric(**payload.dict())
+    session.add(metric)
+    await session.flush()
+    await publish(StreamChannel.RISK, {"id": str(metric.id), **payload.dict()})
+    return {"id": metric.id}
+
+
+@app.post("/sentiment", dependencies=[Depends(require_role("analyst"))])
+async def create_sentiment(payload: SentimentIn, session: AsyncSession = Depends(get_session)) -> Dict[str, int]:
+    """Store sentiment data and publish it."""
+    sentiment = Sentiment(**payload.dict())
+    session.add(sentiment)
+    await session.flush()
+    await publish(StreamChannel.SENTIMENT, {"id": str(sentiment.id), **payload.dict()})
+    return {"id": sentiment.id}
+
+
+app.include_router(ws_router)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,10 @@ redis[hiredis]==5.0.0
 asyncpg==0.29.0
 prometheus-client==0.20.0
 python-dotenv==1.0.1
+apscheduler==3.10.4
+python-jose[cryptography]==3.3.0
+passlib[bcrypt]==1.7.4
+pyotp==2.9.0
+sqlalchemy[asyncio]==2.0.29
+pydantic-settings==2.2.1
+aiosqlite==0.20.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import os
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+# ensure local app package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from fastapi.testclient import TestClient
+
+os.environ["POSTGRES_URL"] = "sqlite+aiosqlite:///:memory:"
+os.environ["REDIS_URL"] = "redis://localhost:6379/0"
+os.environ["JWT_SECRET"] = "testsecret"
+
+from app.auth import get_password_hash
+from app.db import session_scope, init_db
+from app.models import User
+from main import app
+
+
+@pytest.fixture(autouse=True)
+def no_redis(monkeypatch):
+    async def dummy_publish(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("app.redis_streams.publish", dummy_publish);
+    monkeypatch.setattr("main.publish", dummy_publish)
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    asyncio.get_event_loop().run_until_complete(init_db())
+
+    async def create_user() -> None:
+        async with session_scope() as session:
+            user = User(username="alice", hashed_password=get_password_hash("wonder"), role="trader")
+            session.add(user)
+            await session.commit()
+
+    asyncio.get_event_loop().run_until_complete(create_user())
+    with TestClient(app) as c:
+        yield c
+
+
+def test_health(client: TestClient) -> None:
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_auth_and_order_flow(client: TestClient) -> None:
+    token_resp = client.post("/auth/token", data={"username": "alice", "password": "wonder"})
+    assert token_resp.status_code == 200
+    token = token_resp.json()["access_token"]
+    order_resp = client.post(
+        "/orders",
+        json={
+            "symbol": "AAPL",
+            "price": 100.0,
+            "capital": 1000.0,
+            "win_prob": 0.6,
+            "win_loss_ratio": 1.5,
+            "var_limit": 0.5,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert order_resp.status_code == 200
+    assert "quantity" in order_resp.json()


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and PostgreSQL session management
- publish/subscribe Redis streams with WebSocket fan-out
- implement JWT auth with optional TOTP and role checks
- schedule warmup, housekeeping, and backtest jobs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68995e1f05d08323950b0d1343b8578a