### PR TITLE
feat: scaffold React Native mobile app

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,2 @@
+WS_URL=wss://example.com/stream
+API_BASE_URL=https://api.example.com

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,26 @@
+/**
+ * Entry point for the ANGEL.AI mobile trading application.
+ */
+import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import OnboardingScreen from './src/screens/OnboardingScreen';
+import DashboardScreen from './src/screens/DashboardScreen';
+
+const queryClient = new QueryClient();
+
+export default function App(): React.JSX.Element {
+  const [complete, setComplete] = useState(false);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <SafeAreaView style={{ flex: 1 }}>
+        {complete ? (
+          <DashboardScreen />
+        ) : (
+          <OnboardingScreen onFinish={() => setComplete(true)} />
+        )}
+      </SafeAreaView>
+    </QueryClientProvider>
+  );
+}

--- a/mobile/__tests__/useRiskStore.test.ts
+++ b/mobile/__tests__/useRiskStore.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { useRiskStore } from '../src/store/useRiskStore';
+
+describe('useRiskStore', () => {
+  it('toggles kill switch', () => {
+    const { killSwitch, toggleKillSwitch } = useRiskStore.getState();
+    expect(killSwitch).toBe(false);
+    toggleKillSwitch();
+    expect(useRiskStore.getState().killSwitch).toBe(true);
+  });
+});

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "angel-ai-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.tsx",
+  "scripts": {
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "18.3.1",
+    "react-native": "0.74.3",
+    "@tanstack/react-query": "5.84.2",
+    "zustand": "4.5.2",
+    "react-native-svg": "15.1.0"
+  }
+}

--- a/mobile/src/components/GlassCard.tsx
+++ b/mobile/src/components/GlassCard.tsx
@@ -1,0 +1,19 @@
+/**
+ * GlassCard renders content with a glassmorphism style.
+ */
+import React from 'react';
+import { View, StyleSheet, ViewProps } from 'react-native';
+
+export default function GlassCard({ children, style }: React.PropsWithChildren<ViewProps>): React.JSX.Element {
+  return <View style={[styles.card, style]}>{children}</View>;
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: 'rgba(255, 255, 255, 0.1)',
+    borderColor: 'rgba(255, 255, 255, 0.3)',
+    borderWidth: 1,
+    borderRadius: 16,
+    padding: 16,
+  },
+});

--- a/mobile/src/hooks/useMarketData.ts
+++ b/mobile/src/hooks/useMarketData.ts
@@ -1,0 +1,38 @@
+/**
+ * useMarketData streams price updates over WebSocket with auto-reconnect.
+ */
+import { useEffect, useState } from 'react';
+
+const WS_URL = process.env.WS_URL ?? '';
+
+export default function useMarketData(): number {
+  const [price, setPrice] = useState(0);
+
+  useEffect((): (() => void) => {
+    let ws: WebSocket | null = null;
+    let timer: NodeJS.Timeout;
+
+    const connect = (): void => {
+      ws = new WebSocket(WS_URL);
+      ws.onmessage = (event): void => {
+        try {
+          const data = JSON.parse(event.data);
+          if (typeof data.price === 'number') setPrice(data.price);
+        } catch {
+          /* ignore malformed messages */
+        }
+      };
+      ws.onclose = (): void => {
+        timer = setTimeout(connect, 1000);
+      };
+    };
+
+    connect();
+    return (): void => {
+      if (ws) ws.close();
+      clearTimeout(timer);
+    };
+  }, []);
+
+  return price;
+}

--- a/mobile/src/screens/AgentsScreen.tsx
+++ b/mobile/src/screens/AgentsScreen.tsx
@@ -1,0 +1,27 @@
+/**
+ * AgentsScreen provides management for automated trading agents.
+ */
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import GlassCard from '../components/GlassCard';
+
+export default function AgentsScreen(): React.JSX.Element {
+  return (
+    <View style={styles.container}>
+      <GlassCard>
+        <Text style={styles.text}>No agents configured.</Text>
+      </GlassCard>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+    padding: 16,
+  },
+  text: {
+    color: '#fff',
+  },
+});

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -1,0 +1,40 @@
+/**
+ * DashboardScreen displays trading widgets and live market data.
+ */
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import GlassCard from '../components/GlassCard';
+import useMarketData from '../hooks/useMarketData';
+import { useRiskStore } from '../store/useRiskStore';
+
+export default function DashboardScreen(): React.JSX.Element {
+  const price = useMarketData();
+  const { killSwitch, toggleKillSwitch } = useRiskStore();
+
+  return (
+    <View style={styles.container}>
+      <GlassCard style={styles.widget}>
+        <Text style={styles.label}>BTC/USD</Text>
+        <Text style={styles.value}>{price.toFixed(2)}</Text>
+      </GlassCard>
+      <GlassCard style={styles.widget}>
+        <Text style={styles.label}>Kill Switch: {killSwitch ? 'ON' : 'OFF'}</Text>
+        <Text style={styles.link} onPress={toggleKillSwitch}>
+          Toggle
+        </Text>
+      </GlassCard>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+    padding: 16,
+  },
+  widget: { marginBottom: 16 },
+  label: { color: '#0ff', marginBottom: 4 },
+  value: { color: '#fff', fontSize: 20 },
+  link: { color: '#a0a0ff', marginTop: 8 },
+});

--- a/mobile/src/screens/OnboardingScreen.tsx
+++ b/mobile/src/screens/OnboardingScreen.tsx
@@ -1,0 +1,43 @@
+/**
+ * OnboardingScreen guides new users through initial setup.
+ */
+import React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import GlassCard from '../components/GlassCard';
+
+export interface OnboardingProps {
+  onFinish: () => void;
+}
+
+export default function OnboardingScreen({ onFinish }: OnboardingProps): React.JSX.Element {
+  return (
+    <View style={styles.container}>
+      <GlassCard>
+        <Text style={styles.title}>ANGEL.AI</Text>
+        <Text style={styles.tagline}>Divine Execution. Extreme Profits.</Text>
+        <Button title="Enter" onPress={onFinish} />
+      </GlassCard>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#000',
+  },
+  title: {
+    fontSize: 24,
+    color: '#0ff',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  tagline: {
+    fontSize: 12,
+    color: '#a0a0ff',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+});

--- a/mobile/src/screens/PortfolioScreen.tsx
+++ b/mobile/src/screens/PortfolioScreen.tsx
@@ -1,0 +1,27 @@
+/**
+ * PortfolioScreen visualizes asset allocations and performance.
+ */
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import GlassCard from '../components/GlassCard';
+
+export default function PortfolioScreen(): React.JSX.Element {
+  return (
+    <View style={styles.container}>
+      <GlassCard>
+        <Text style={styles.text}>Portfolio visualization coming soon.</Text>
+      </GlassCard>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+    padding: 16,
+  },
+  text: {
+    color: '#fff',
+  },
+});

--- a/mobile/src/store/useRiskStore.ts
+++ b/mobile/src/store/useRiskStore.ts
@@ -1,0 +1,18 @@
+/**
+ * useRiskStore manages global risk controls.
+ */
+import { create } from 'zustand';
+
+export interface RiskState {
+  killSwitch: boolean;
+  maxDrawdown: number;
+  toggleKillSwitch: () => void;
+  setMaxDrawdown: (value: number) => void;
+}
+
+export const useRiskStore = create<RiskState>((set) => ({
+  killSwitch: false,
+  maxDrawdown: 0.2,
+  toggleKillSwitch: () => set((s) => ({ killSwitch: !s.killSwitch })),
+  setMaxDrawdown: (value: number) => set({ maxDrawdown: value }),
+}));

--- a/mobile/src/utils/positionSizing.ts
+++ b/mobile/src/utils/positionSizing.ts
@@ -1,0 +1,15 @@
+/**
+ * Utility functions for dynamic position sizing.
+ */
+export function kelly(p: number, b: number): number {
+  if (b <= 0) throw new Error('b must be > 0');
+  if (p <= 0 || p >= 1) throw new Error('p must be between 0 and 1');
+  return Math.max(0, (p * (b + 1) - 1) / b);
+}
+
+export function valueAtRisk(returns: number[], confidence: number): number {
+  if (confidence <= 0 || confidence >= 1) throw new Error('confidence must be between 0 and 1');
+  const sorted = [...returns].sort((a, b) => a - b);
+  const index = Math.floor((1 - confidence) * sorted.length);
+  return Math.abs(sorted[index] ?? 0);
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["react", "react-native"],
+    "baseUrl": "./",
+    "paths": {
+      "@/": ["src/*"]
+    }
+  },
+  "include": ["src", "App.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/web/src/tests/dashboardGrid.test.tsx
+++ b/web/src/tests/dashboardGrid.test.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
 import { DashboardGrid } from '../components/DashboardGrid';
 
-jest.mock('../lib/firebase', () => ({ db: {} }));
-jest.mock('firebase/firestore', () => ({
-  doc: jest.fn(),
-  getDoc: jest.fn(() => Promise.resolve({ exists: () => false })),
-  setDoc: jest.fn(() => Promise.resolve()),
+vi.mock('../lib/firebase', () => ({ db: {} }));
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn(),
+  getDoc: vi.fn(() => Promise.resolve({ exists: () => false })),
+  setDoc: vi.fn(() => Promise.resolve()),
 }));
 
 test('renders default widgets', async () => {


### PR DESCRIPTION
## Summary
- add initial React Native mobile scaffold with glassmorphism UI
- implement risk store with kill switch and position sizing utilities
- switch dashboard grid test to vitest mocks

## Testing
- `npm test`
- `npx vitest mobile/__tests__/useRiskStore.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a1bbe4d708323bc3d87ff3c8cd6c6