### PR TITLE
feat: add trading agents and meta governor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Environment configuration for ANGEL-AI-X agents
+BROKER_API_KEY=your_broker_api_key
+DATA_FEED_URL=wss://feed.example.com
+ADMIN_HEALTH_WINDOW=60

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+node_modules/
+.pytest_cache/
+.env
+*.pyc
+package-lock.json

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package for trading agents."""

--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -1,0 +1,17 @@
+"""Agent strategy package exposing trading agents and governance utilities."""
+
+from .base import Signal, AgentKPI, TradingAgent
+from .momentum import MomentumAgent
+from .mean_reversion import MeanReversionAgent
+from .admin import AdminAgent
+from .meta_governor import MetaGovernor
+
+__all__ = [
+    "Signal",
+    "AgentKPI",
+    "TradingAgent",
+    "MomentumAgent",
+    "MeanReversionAgent",
+    "AdminAgent",
+    "MetaGovernor",
+]

--- a/app/agents/admin.py
+++ b/app/agents/admin.py
@@ -1,0 +1,46 @@
+"""Administrative agent supervising strategy health and promotions."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Dict, Set
+
+from .base import TradingAgent
+
+
+class AdminAgent:
+    """Tracks agent health and manages promotions based on KPIs."""
+
+    def __init__(self, health_window: int = 60) -> None:
+        self._agents: Dict[str, TradingAgent] = {}
+        self._last_update: Dict[str, datetime] = {}
+        self._promoted: Set[str] = set()
+        self._health_window = timedelta(seconds=health_window)
+
+    def register(self, agent: TradingAgent) -> None:
+        if agent.agent_id in self._agents:
+            raise ValueError(f"Agent {agent.agent_id} already registered")
+        self._agents[agent.agent_id] = agent
+        self._last_update[agent.agent_id] = datetime.now(UTC)
+
+    def mark_updated(self, agent_id: str) -> None:
+        self._last_update[agent_id] = datetime.now(UTC)
+
+    def check_health(self) -> Dict[str, bool]:
+        now = datetime.now(UTC)
+        return {
+            agent_id: now - self._last_update.get(agent_id, datetime.min.replace(tzinfo=UTC)) < self._health_window
+            for agent_id in self._agents
+        }
+
+    def evaluate_promotions(self, threshold: float) -> None:
+        for agent_id, agent in self._agents.items():
+            if agent.kpi.weight() >= threshold:
+                self._promoted.add(agent_id)
+
+    def is_promoted(self, agent_id: str) -> bool:
+        return agent_id in self._promoted
+
+    @property
+    def agents(self) -> Dict[str, TradingAgent]:
+        return dict(self._agents)

--- a/app/agents/base.py
+++ b/app/agents/base.py
@@ -1,0 +1,74 @@
+"""Common agent primitives and data models for trading strategies."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Literal
+
+from app.core import kelly_blend
+
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(slots=True)
+class Signal:
+    """Represents a trading signal emitted by an agent."""
+
+    schema_version: int
+    timestamp: datetime
+    symbol: str
+    action: Literal["BUY", "SELL", "HOLD"]
+    confidence: float
+    size: float
+
+
+@dataclass(slots=True)
+class AgentKPI:
+    """Key performance indicators tracked for each agent."""
+
+    sharpe_ratio: float
+    win_rate: float
+    max_drawdown: float
+
+    def weight(self) -> float:
+        """Return a positive weight derived from KPIs for voting and sizing."""
+        penalty = max(self.max_drawdown, 1e-6)
+        return max(self.sharpe_ratio * self.win_rate / penalty, 0.0)
+
+
+class TradingAgent(ABC):
+    """Abstract base class for trading agents."""
+
+    def __init__(self, agent_id: str, admin: "AdminAgent", *, kpi: AgentKPI) -> None:
+        self.agent_id = agent_id
+        self._admin = admin
+        self.kpi = kpi
+        self._state: Dict[str, Any] = {}
+        self._admin.register(self)
+
+    @property
+    def state(self) -> Dict[str, Any]:
+        """Return a shallow copy of the current agent state."""
+        return dict(self._state)
+
+    @abstractmethod
+    async def generate_signal(self) -> Signal:
+        """Produce a trading signal based on the agent's state.
+
+        Implementations must include risk controls and dynamic sizing.
+        """
+
+    @abstractmethod
+    async def update_state(self, market_data: Dict[str, Any]) -> None:
+        """Update internal state from validated market data."""
+
+    async def _kelly_size(self, edge: float, variance: float, capital: float, cvar: float = 0.1) -> float:
+        """Calculate position size using the Kelly criterion with CVaR cap."""
+        if variance <= 0:
+            raise ValueError("Variance must be positive for Kelly sizing")
+        sigma = variance ** 0.5
+        fraction = kelly_blend(edge, sigma, cvar)
+        return capital * fraction

--- a/app/agents/mean_reversion.py
+++ b/app/agents/mean_reversion.py
@@ -1,0 +1,80 @@
+"""Mean reversion trading agent."""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import UTC, datetime
+from typing import Any, Deque, Dict
+
+from .admin import AdminAgent
+from .base import SCHEMA_VERSION, AgentKPI, Signal, TradingAgent
+from app.core import adaptive_position_size, garch_scaled_atr
+
+
+class MeanReversionAgent(TradingAgent):
+    """Contrarian strategy that bets on prices reverting to their mean."""
+
+    def __init__(
+        self,
+        agent_id: str,
+        admin: AdminAgent,
+        *,
+        kpi: AgentKPI,
+        window: int = 10,
+        threshold: float = 0.01,
+        capital: float = 10_000,
+    ) -> None:
+        super().__init__(agent_id, admin, kpi=kpi)
+        self._prices: Deque[float] = deque(maxlen=window)
+        self._threshold = threshold
+        self._capital = capital
+
+    async def update_state(self, market_data: Dict[str, Any]) -> None:
+        price = market_data.get("price")
+        symbol = market_data.get("symbol")
+        if not isinstance(price, (int, float)) or not isinstance(symbol, str):
+            raise ValueError("Invalid market data for MeanReversionAgent")
+        self._prices.append(float(price))
+        self._state["symbol"] = symbol
+        self._admin.mark_updated(self.agent_id)
+
+    async def generate_signal(self) -> Signal:
+        if len(self._prices) < self._prices.maxlen:
+            return Signal(
+                schema_version=SCHEMA_VERSION,
+                timestamp=datetime.now(UTC),
+                symbol=self._state.get("symbol", ""),
+                action="HOLD",
+                confidence=0.0,
+                size=0.0,
+            )
+        avg = sum(self._prices) / len(self._prices)
+        last = self._prices[-1]
+        deviation = (last - avg) / avg
+        variance = max(sum((p - avg) ** 2 for p in self._prices) / len(self._prices), 1e-6)
+        sigma = variance ** 0.5
+        atr = sum(abs(self._prices[i] - self._prices[i - 1]) for i in range(1, len(self._prices))) / (
+            len(self._prices) - 1
+        )
+        adj_atr = garch_scaled_atr(atr, sigma)
+        edge = -deviation
+        kelly = await self._kelly_size(edge, variance, 1.0)
+        confidence = min(abs(deviation) * 10, 1.0)
+        size = adaptive_position_size(
+            self._capital, adj_atr, sigma, kelly, dd_frac=0.0, trend_conf=confidence, regime=True
+        )
+        if deviation > self._threshold:
+            action = "SELL"
+        elif deviation < -self._threshold:
+            action = "BUY"
+        else:
+            action = "HOLD"
+            size = 0.0
+        return Signal(
+            schema_version=SCHEMA_VERSION,
+            timestamp=datetime.now(UTC),
+            symbol=self._state.get("symbol", ""),
+            action=action,
+            confidence=confidence,
+            size=size,
+        )

--- a/app/agents/meta_governor.py
+++ b/app/agents/meta_governor.py
@@ -1,0 +1,43 @@
+"""Meta governor aggregating agent signals and allocating capital."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Dict, Tuple
+
+from .admin import AdminAgent
+from .base import SCHEMA_VERSION, Signal
+
+
+class MetaGovernor:
+    """Aggregates signals via weighted voting and decides capital allocation."""
+
+    def __init__(self, admin: AdminAgent, total_capital: float = 100_000) -> None:
+        self._admin = admin
+        self._capital = total_capital
+
+    async def vote_and_allocate(self) -> Tuple[Signal, Dict[str, float]]:
+        agents = list(self._admin.agents.values())
+        if not agents:
+            raise ValueError("No agents registered for voting")
+        signals = await asyncio.gather(*(agent.generate_signal() for agent in agents))
+        weights = [agent.kpi.weight() for agent in agents]
+        total_weight = sum(weights) or 1.0
+        decision_score = 0.0
+        allocations: Dict[str, float] = {}
+        for agent, signal, weight in zip(agents, signals, weights):
+            direction = {"BUY": 1, "SELL": -1, "HOLD": 0}[signal.action]
+            decision_score += direction * weight * signal.confidence
+            allocations[agent.agent_id] = self._capital * (weight / total_weight)
+        final_action = "BUY" if decision_score > 0 else "SELL" if decision_score < 0 else "HOLD"
+        confidence = min(abs(decision_score) / (total_weight or 1.0), 1.0)
+        final_signal = Signal(
+            schema_version=SCHEMA_VERSION,
+            timestamp=datetime.now(UTC),
+            symbol=signals[0].symbol,
+            action=final_action,
+            confidence=confidence,
+            size=self._capital * confidence,
+        )
+        return final_signal, allocations

--- a/app/agents/momentum.py
+++ b/app/agents/momentum.py
@@ -1,0 +1,71 @@
+"""Momentum-based trading agent."""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import UTC, datetime
+from typing import Any, Deque, Dict
+
+from .admin import AdminAgent
+from .base import SCHEMA_VERSION, AgentKPI, Signal, TradingAgent
+from app.core import adaptive_position_size, garch_scaled_atr
+
+
+class MomentumAgent(TradingAgent):
+    """Simple momentum strategy relying on recent price trends."""
+
+    def __init__(
+        self,
+        agent_id: str,
+        admin: AdminAgent,
+        *,
+        kpi: AgentKPI,
+        lookback: int = 5,
+        capital: float = 10_000,
+    ) -> None:
+        super().__init__(agent_id, admin, kpi=kpi)
+        self._prices: Deque[float] = deque(maxlen=lookback)
+        self._capital = capital
+
+    async def update_state(self, market_data: Dict[str, Any]) -> None:
+        price = market_data.get("price")
+        symbol = market_data.get("symbol")
+        if not isinstance(price, (int, float)) or not isinstance(symbol, str):
+            raise ValueError("Invalid market data for MomentumAgent")
+        self._prices.append(float(price))
+        self._state["symbol"] = symbol
+        self._admin.mark_updated(self.agent_id)
+
+    async def generate_signal(self) -> Signal:
+        if len(self._prices) < self._prices.maxlen:
+            return Signal(
+                schema_version=SCHEMA_VERSION,
+                timestamp=datetime.now(UTC),
+                symbol=self._state.get("symbol", ""),
+                action="HOLD",
+                confidence=0.0,
+                size=0.0,
+            )
+        avg = sum(self._prices) / len(self._prices)
+        last = self._prices[-1]
+        edge = (last - avg) / avg
+        variance = max(sum((p - avg) ** 2 for p in self._prices) / len(self._prices), 1e-6)
+        sigma = variance ** 0.5
+        atr = sum(abs(self._prices[i] - self._prices[i - 1]) for i in range(1, len(self._prices))) / (
+            len(self._prices) - 1
+        )
+        adj_atr = garch_scaled_atr(atr, sigma)
+        kelly = await self._kelly_size(edge, variance, 1.0)
+        confidence = min(abs(edge) * 10, 1.0)
+        size = adaptive_position_size(
+            self._capital, adj_atr, sigma, kelly, dd_frac=0.0, trend_conf=confidence, regime=True
+        )
+        action = "BUY" if edge > 0 else "SELL"
+        return Signal(
+            schema_version=SCHEMA_VERSION,
+            timestamp=datetime.now(UTC),
+            symbol=self._state.get("symbol", ""),
+            action=action,
+            confidence=confidence,
+            size=size,
+        )

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,10 @@
+"""Core risk and position utilities for trading agents."""
+
+from .risk import garch_scaled_atr, kelly_blend
+from .position import adaptive_position_size
+
+__all__ = [
+    "garch_scaled_atr",
+    "kelly_blend",
+    "adaptive_position_size",
+]

--- a/app/core/position.py
+++ b/app/core/position.py
@@ -1,0 +1,21 @@
+"""Position sizing helper."""
+
+from __future__ import annotations
+
+def adaptive_position_size(
+    nav: float,
+    atr: float,
+    sigma: float,
+    kelly: float,
+    dd_frac: float,
+    trend_conf: float,
+    regime: bool,
+) -> float:
+    """Calculate position size with volatility and drawdown adjustments."""
+    if nav <= 0 or atr <= 0:
+        raise ValueError("nav and atr must be positive")
+    vol_penalty = 1.0 / (1.0 + 2.0 * sigma)
+    trend_boost = 1.0 + 0.5 * max(0.0, trend_conf - 0.6)
+    dd_penalty = 1.0 - min(0.8, dd_frac * 2.0)
+    raw = nav * kelly * vol_penalty * trend_boost * dd_penalty
+    return raw if regime else 0.0

--- a/app/core/risk.py
+++ b/app/core/risk.py
@@ -1,0 +1,33 @@
+"""Risk management utilities."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+# Hard-coded risk limits
+GROWTH_TARGET_DAILY: float = 0.05
+MAX_DD_DAILY: float = 0.02
+MAX_DD_INTRADAY: float = 0.015
+MAX_LEVERAGE: float = 2.0
+
+def garch_scaled_atr(atr: float, sigma: float) -> float:
+    """Scale the ATR by a simple GARCH-like volatility adjustment."""
+    if atr <= 0 or sigma < 0:
+        raise ValueError("ATR and sigma must be positive")
+    return atr * (1.0 + 0.5 * sigma)
+
+def kelly_blend(mu: float, sigma: float, cvar: float, cap: float = 0.25) -> float:
+    """Blend Kelly sizing with CVaR to cap excessive bets."""
+    if sigma <= 0:
+        raise ValueError("sigma must be positive")
+    k_raw = mu / max(1e-9, sigma ** 2)
+    k_cvar = 1.0 / (1.0 + 10 * max(cvar, 1e-9))
+    return min(max(0.0, k_raw * k_cvar), cap)
+
+def risk_precheck(lev_next: float, dd_today: float) -> Tuple[bool, str]:
+    """Basic leverage and drawdown guardrails."""
+    if dd_today > MAX_DD_DAILY:
+        return False, "daily_dd_limit"
+    if lev_next > MAX_LEVERAGE:
+        return False, "leverage_cap"
+    return True, "ok"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ redis[hiredis]==5.0.0
 asyncpg==0.29.0
 prometheus-client==0.20.0
 python-dotenv==1.0.1
+pytest==8.4.1
+pytest-asyncio==1.1.0

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,38 @@
+"""Tests for trading agents and governance components."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.agents import (
+    AdminAgent,
+    AgentKPI,
+    MeanReversionAgent,
+    MetaGovernor,
+    MomentumAgent,
+)
+
+
+@pytest.mark.asyncio
+async def test_meta_governor_allocation() -> None:
+    admin = AdminAgent()
+    kpi_mom = AgentKPI(sharpe_ratio=1.0, win_rate=0.6, max_drawdown=0.1)
+    kpi_mean = AgentKPI(sharpe_ratio=1.5, win_rate=0.65, max_drawdown=0.05)
+    mom = MomentumAgent("mom", admin, kpi=kpi_mom)
+    mean = MeanReversionAgent("mean", admin, kpi=kpi_mean)
+    for price in range(1, 12):
+        data = {"symbol": "XYZ", "price": float(price)}
+        await mom.update_state(data)
+        await mean.update_state(data)
+    health = admin.check_health()
+    assert all(health.values())
+    admin.evaluate_promotions(threshold=1.0)
+    assert admin.is_promoted("mean")
+    governor = MetaGovernor(admin, total_capital=100_000)
+    signal, allocations = await governor.vote_and_allocate()
+    assert signal.action in {"BUY", "SELL", "HOLD"}
+    assert pytest.approx(sum(allocations.values()), rel=1e-6) == 100_000
+    assert allocations["mean"] > allocations["mom"]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,24 @@
+"""Tests for core risk and position sizing utilities."""
+
+import pytest
+
+from app.core import adaptive_position_size, garch_scaled_atr, kelly_blend
+
+
+def test_garch_scaled_atr() -> None:
+    atr = 2.0
+    sigma = 0.5
+    scaled = garch_scaled_atr(atr, sigma)
+    assert pytest.approx(scaled, rel=1e-6) == atr * (1 + 0.5 * sigma)
+
+
+def test_adaptive_position_size() -> None:
+    size = adaptive_position_size(1000, atr=1.0, sigma=0.2, kelly=0.1, dd_frac=0.0, trend_conf=0.7, regime=True)
+    assert size > 0
+    size_no_regime = adaptive_position_size(1000, atr=1.0, sigma=0.2, kelly=0.1, dd_frac=0.0, trend_conf=0.7, regime=False)
+    assert size_no_regime == 0
+
+
+def test_kelly_blend_bounds() -> None:
+    k = kelly_blend(mu=0.1, sigma=0.2, cvar=0.1)
+    assert 0.0 <= k <= 0.25


### PR DESCRIPTION
## Summary
- add base trading agent framework and momentum/mean-reversion strategies
- track agent health/promotion via AdminAgent and aggregate decisions with MetaGovernor
- document env variables and add tests for weighted voting and allocation
- add core risk utilities with adaptive position sizing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68995e00d5d083238debed6757dd5f88