### PR TITLE
feat: add trading agents and meta governor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Environment configuration for ANGEL-AI-X agents
+BROKER_API_KEY=your_broker_api_key
+DATA_FEED_URL=wss://feed.example.com
+ADMIN_HEALTH_WINDOW=60

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+node_modules/
+.pytest_cache/
+.env
+*.pyc
+package-lock.json

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package for trading agents."""

--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -1,0 +1,17 @@
+"""Agent strategy package exposing trading agents and governance utilities."""
+
+from .base import Signal, AgentKPI, TradingAgent
+from .momentum import MomentumAgent
+from .mean_reversion import MeanReversionAgent
+from .admin import AdminAgent
+from .meta_governor import MetaGovernor
+
+__all__ = [
+    "Signal",
+    "AgentKPI",
+    "TradingAgent",
+    "MomentumAgent",
+    "MeanReversionAgent",
+    "AdminAgent",
+    "MetaGovernor",
+]

--- a/app/agents/base.py
+++ b/app/agents/base.py
@@ -1,0 +1,71 @@
+"""Common agent primitives and data models for trading strategies."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Literal
+
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(slots=True)
+class Signal:
+    """Represents a trading signal emitted by an agent."""
+
+    schema_version: int
+    timestamp: datetime
+    symbol: str
+    action: Literal["BUY", "SELL", "HOLD"]
+    confidence: float
+    size: float
+
+
+@dataclass(slots=True)
+class AgentKPI:
+    """Key performance indicators tracked for each agent."""
+
+    sharpe_ratio: float
+    win_rate: float
+    max_drawdown: float
+
+    def weight(self) -> float:
+        """Return a positive weight derived from KPIs for voting and sizing."""
+        penalty = max(self.max_drawdown, 1e-6)
+        return max(self.sharpe_ratio * self.win_rate / penalty, 0.0)
+
+
+class TradingAgent(ABC):
+    """Abstract base class for trading agents."""
+
+    def __init__(self, agent_id: str, admin: "AdminAgent", *, kpi: AgentKPI) -> None:
+        self.agent_id = agent_id
+        self._admin = admin
+        self.kpi = kpi
+        self._state: Dict[str, Any] = {}
+        self._admin.register(self)
+
+    @property
+    def state(self) -> Dict[str, Any]:
+        """Return a shallow copy of the current agent state."""
+        return dict(self._state)
+
+    @abstractmethod
+    async def generate_signal(self) -> Signal:
+        """Produce a trading signal based on the agent's state.
+
+        Implementations must include risk controls and dynamic sizing.
+        """
+
+    @abstractmethod
+    async def update_state(self, market_data: Dict[str, Any]) -> None:
+        """Update internal state from validated market data."""
+
+    async def _kelly_size(self, edge: float, variance: float, capital: float) -> float:
+        """Calculate position size using the Kelly criterion."""
+        if variance <= 0:
+            raise ValueError("Variance must be positive for Kelly sizing")
+        fraction = max(min(edge / variance, 1.0), 0.0)
+        return capital * fraction

--- a/app/agents/mean_reversion.py
+++ b/app/agents/mean_reversion.py
@@ -1,0 +1,73 @@
+"""Mean reversion trading agent."""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import UTC, datetime
+from typing import Any, Deque, Dict
+
+from .admin import AdminAgent
+from .base import SCHEMA_VERSION, AgentKPI, Signal, TradingAgent
+
+
+class MeanReversionAgent(TradingAgent):
+    """Contrarian strategy that bets on prices reverting to their mean."""
+
+    def __init__(
+        self,
+        agent_id: str,
+        admin: AdminAgent,
+        *,
+        kpi: AgentKPI,
+        window: int = 10,
+        threshold: float = 0.01,
+        capital: float = 10_000,
+    ) -> None:
+        super().__init__(agent_id, admin, kpi=kpi)
+        self._prices: Deque[float] = deque(maxlen=window)
+        self._threshold = threshold
+        self._capital = capital
+
+    async def update_state(self, market_data: Dict[str, Any]) -> None:
+        """Update price window for mean-reversion calculation."""
+        price = market_data.get("price")
+        symbol = market_data.get("symbol")
+        if not isinstance(price, (int, float)) or not isinstance(symbol, str):
+            raise ValueError("Invalid market data for MeanReversionAgent")
+        self._prices.append(float(price))
+        self._state["symbol"] = symbol
+        self._admin.mark_updated(self.agent_id)
+
+    async def generate_signal(self) -> Signal:
+        """Produce a mean-reversion trading signal."""
+        if len(self._prices) < self._prices.maxlen:
+            return Signal(
+                schema_version=SCHEMA_VERSION,
+                timestamp=datetime.now(UTC),
+                symbol=self._state.get("symbol", ""),
+                action="HOLD",
+                confidence=0.0,
+                size=0.0,
+            )
+        avg = sum(self._prices) / len(self._prices)
+        last = self._prices[-1]
+        deviation = (last - avg) / avg
+        variance = max(sum((p - avg) ** 2 for p in self._prices) / len(self._prices), 1e-6)
+        edge = -deviation
+        size = await self._kelly_size(edge, variance, self._capital)
+        if deviation > self._threshold:
+            action = "SELL"
+        elif deviation < -self._threshold:
+            action = "BUY"
+        else:
+            action = "HOLD"
+            size = 0.0
+        confidence = min(abs(deviation) * 10, 1.0)
+        return Signal(
+            schema_version=SCHEMA_VERSION,
+            timestamp=datetime.now(UTC),
+            symbol=self._state.get("symbol", ""),
+            action=action,
+            confidence=confidence,
+            size=size,
+        )

--- a/app/agents/meta_governor.py
+++ b/app/agents/meta_governor.py
@@ -1,0 +1,47 @@
+"""Meta governor aggregating agent signals and allocating capital."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Dict, Tuple
+
+from .admin import AdminAgent
+from .base import SCHEMA_VERSION, Signal
+
+
+class MetaGovernor:
+    """Aggregates signals via weighted voting and decides capital allocation."""
+
+    def __init__(self, admin: AdminAgent, total_capital: float = 100_000) -> None:
+        self._admin = admin
+        self._capital = total_capital
+
+    async def vote_and_allocate(self) -> Tuple[Signal, Dict[str, float]]:
+        """Compute a weighted vote and capital allocation across agents."""
+        agents = list(self._admin.agents.values())
+        if not agents:
+            raise ValueError("No agents registered for voting")
+        signals = await asyncio.gather(*(agent.generate_signal() for agent in agents))
+        symbols = {s.symbol for s in signals}
+        if len(symbols) != 1:
+            raise ValueError("Signals reference multiple symbols")
+        weights = [agent.kpi.weight() for agent in agents]
+        total_weight = sum(weights) or 1.0
+        decision_score = 0.0
+        allocations: Dict[str, float] = {}
+        for agent, signal, weight in zip(agents, signals, weights):
+            direction = {"BUY": 1, "SELL": -1, "HOLD": 0}[signal.action]
+            decision_score += direction * weight * signal.confidence
+            allocations[agent.agent_id] = self._capital * (weight / total_weight)
+        final_action = "BUY" if decision_score > 0 else "SELL" if decision_score < 0 else "HOLD"
+        confidence = min(abs(decision_score) / (total_weight or 1.0), 1.0)
+        final_signal = Signal(
+            schema_version=SCHEMA_VERSION,
+            timestamp=datetime.now(UTC),
+            symbol=next(iter(symbols)),
+            action=final_action,
+            confidence=confidence,
+            size=self._capital * confidence,
+        )
+        return final_signal, allocations

--- a/app/agents/momentum.py
+++ b/app/agents/momentum.py
@@ -1,0 +1,64 @@
+"""Momentum-based trading agent."""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import UTC, datetime
+from typing import Any, Deque, Dict
+
+from .admin import AdminAgent
+from .base import SCHEMA_VERSION, AgentKPI, Signal, TradingAgent
+
+
+class MomentumAgent(TradingAgent):
+    """Simple momentum strategy relying on recent price trends."""
+
+    def __init__(
+        self,
+        agent_id: str,
+        admin: AdminAgent,
+        *,
+        kpi: AgentKPI,
+        lookback: int = 5,
+        capital: float = 10_000,
+    ) -> None:
+        super().__init__(agent_id, admin, kpi=kpi)
+        self._prices: Deque[float] = deque(maxlen=lookback)
+        self._capital = capital
+
+    async def update_state(self, market_data: Dict[str, Any]) -> None:
+        """Ingest latest price for momentum calculation."""
+        price = market_data.get("price")
+        symbol = market_data.get("symbol")
+        if not isinstance(price, (int, float)) or not isinstance(symbol, str):
+            raise ValueError("Invalid market data for MomentumAgent")
+        self._prices.append(float(price))
+        self._state["symbol"] = symbol
+        self._admin.mark_updated(self.agent_id)
+
+    async def generate_signal(self) -> Signal:
+        """Generate a trading signal based on recent momentum."""
+        if len(self._prices) < self._prices.maxlen:
+            return Signal(
+                schema_version=SCHEMA_VERSION,
+                timestamp=datetime.now(UTC),
+                symbol=self._state.get("symbol", ""),
+                action="HOLD",
+                confidence=0.0,
+                size=0.0,
+            )
+        avg = sum(self._prices) / len(self._prices)
+        last = self._prices[-1]
+        edge = (last - avg) / avg
+        variance = max(sum((p - avg) ** 2 for p in self._prices) / len(self._prices), 1e-6)
+        size = await self._kelly_size(edge, variance, self._capital)
+        action = "BUY" if edge > 0 else "SELL"
+        confidence = min(abs(edge) * 10, 1.0)
+        return Signal(
+            schema_version=SCHEMA_VERSION,
+            timestamp=datetime.now(UTC),
+            symbol=self._state.get("symbol", ""),
+            action=action,
+            confidence=confidence,
+            size=size,
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ redis[hiredis]==5.0.0
 asyncpg==0.29.0
 prometheus-client==0.20.0
 python-dotenv==1.0.1
+pytest==8.4.1
+pytest-asyncio==1.1.0

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,38 @@
+"""Tests for trading agents and governance components."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.agents import (
+    AdminAgent,
+    AgentKPI,
+    MeanReversionAgent,
+    MetaGovernor,
+    MomentumAgent,
+)
+
+
+@pytest.mark.asyncio
+async def test_meta_governor_allocation() -> None:
+    admin = AdminAgent()
+    kpi_mom = AgentKPI(sharpe_ratio=1.0, win_rate=0.6, max_drawdown=0.1)
+    kpi_mean = AgentKPI(sharpe_ratio=1.5, win_rate=0.65, max_drawdown=0.05)
+    mom = MomentumAgent("mom", admin, kpi=kpi_mom)
+    mean = MeanReversionAgent("mean", admin, kpi=kpi_mean)
+    for price in range(1, 12):
+        data = {"symbol": "XYZ", "price": float(price)}
+        await mom.update_state(data)
+        await mean.update_state(data)
+    health = admin.check_health()
+    assert all(health.values())
+    admin.evaluate_promotions(threshold=1.0)
+    assert admin.is_promoted("mean")
+    governor = MetaGovernor(admin, total_capital=100_000)
+    signal, allocations = await governor.vote_and_allocate()
+    assert signal.action in {"BUY", "SELL", "HOLD"}
+    assert pytest.approx(sum(allocations.values()), rel=1e-6) == 100_000
+    assert allocations["mean"] > allocations["mom"]


### PR DESCRIPTION
## Summary
- add base trading agent framework and momentum/mean-reversion strategies
- track agent health/promotion via AdminAgent and aggregate decisions with MetaGovernor
- document env variables and add tests for weighted voting and allocation
- enrich agent docstrings and validate symbol consistency during MetaGovernor voting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68995e00d5d083238debed6757dd5f88