### PR TITLE
Add connection pooling and fix schema tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,33 +1,84 @@
 
-import os, asyncpg, aioredis, logging
-from fastapi import FastAPI, Depends
+"""FastAPI application exposing health and metrics endpoints."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import AsyncGenerator
+
+import aioredis
+import asyncpg
+from fastapi import FastAPI, HTTPException
 from prometheus_client import Counter, Histogram, generate_latest
 from starlette.responses import Response
 
+logger = logging.getLogger(__name__)
+
+
 app = FastAPI(title="ANGEL.AI Backend", version="0.1.0")
 
-REQUEST_TIME = Histogram('http_request_duration_seconds', 'Request latency')
-HITS = Counter('http_request_total', 'Total HTTP hits')
+REQUEST_TIME = Histogram("http_request_duration_seconds", "Request latency")
+HITS = Counter("http_request_total", "Total HTTP hits")
 
-async def get_pg():
-    url = os.getenv("POSTGRES_URL")
-    conn = await asyncpg.connect(dsn=url)
-    return conn
 
-async def get_redis():
-    url = os.getenv("REDIS_URL")
-    return await aioredis.from_url(url, encoding="utf-8", decode_responses=True)
+@app.on_event("startup")
+async def startup() -> None:
+    """Create connection pools for Postgres and Redis."""
+    try:
+        app.state.pg_pool = await asyncpg.create_pool(dsn=os.environ["POSTGRES_URL"])
+    except Exception as exc:  # pragma: no cover - logs for operators
+        logger.error("Postgres pool creation failed", exc_info=exc)
+        raise
+
+    try:
+        app.state.redis = aioredis.from_url(
+            os.environ["REDIS_URL"], encoding="utf-8", decode_responses=True
+        )
+    except Exception as exc:  # pragma: no cover - logs for operators
+        logger.error("Redis client creation failed", exc_info=exc)
+        raise
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    """Close connection pools on shutdown."""
+    await app.state.pg_pool.close()
+    await app.state.redis.close()
+
+
+async def get_pg() -> AsyncGenerator[asyncpg.Connection, None]:
+    """Yield a Postgres connection from the pool."""
+    async with app.state.pg_pool.acquire() as conn:
+        yield conn
+
+
+async def get_redis() -> AsyncGenerator[aioredis.Redis, None]:
+    """Yield the Redis client."""
+    yield app.state.redis
+
 
 @app.middleware("http")
 async def metrics_mw(request, call_next):
+    """Collect Prometheus metrics for each request."""
     HITS.inc()
     with REQUEST_TIME.time():
         return await call_next(request)
 
+
 @app.get("/health")
-async def health():
+async def health() -> dict[str, str]:
+    """Basic liveness probe verifying database connectivity."""
+    try:
+        async with app.state.pg_pool.acquire() as conn:
+            await conn.execute("SELECT 1")
+    except Exception as exc:  # pragma: no cover - logs for operators
+        logger.exception("Health check failed", exc_info=exc)
+        raise HTTPException(status_code=500, detail="database error")
     return {"status": "ok"}
 
+
 @app.get("/metrics")
-async def metrics():
+async def metrics() -> Response:
+    """Expose Prometheus metrics."""
     return Response(generate_latest(), media_type="text/plain")

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,10 +3,16 @@ import Image from 'next/image';
 /**
  * Home page rendering ANGEL.AI branding.
  */
-export default function Home() {
+export default function Home(): JSX.Element {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-4">
-      <Image src="/halo.svg" alt="ANGEL.AI logo" width={80} height={80} />
+      <Image
+        src="/halo.svg"
+        alt="ANGEL.AI logo"
+        width={80}
+        height={80}
+        loading="lazy"
+      />
       <h1 className="font-space text-4xl">ANGEL.AI</h1>
       <p className="font-inter">Divine Execution. Extreme Profits.</p>
     </main>

--- a/tests/test_controlplane_schema.py
+++ b/tests/test_controlplane_schema.py
@@ -3,11 +3,20 @@ from pathlib import Path
 
 
 def test_controlplane_schema_structure():
-    schema_path = Path(__file__).resolve().parent.parent / "controlplane.schema.json"
+    schema_path = (
+        Path(__file__).resolve().parent.parent / "config" / "controlplane.schema.json"
+    )
     with schema_path.open() as f:
         schema = json.load(f)
 
-    assert schema["title"] == "ANGEL Control Plane Command"
-    assert set(schema["required"]) == {"version", "timestamp", "command", "signature"}
-    actions = schema["properties"]["command"]["properties"]["action"]["enum"]
-    assert {"HALT", "RESUME", "GEAR"}.issubset(actions)
+    assert schema["title"] == "ANGEL Control-Plane Envelope v1"
+    assert set(schema["required"]) == {
+        "msg_id",
+        "ts",
+        "issuer",
+        "type",
+        "ttl_ms",
+        "sig",
+    }
+    actions = schema["properties"]["type"]["enum"]
+    assert {"halt", "resume", "gear_set"}.issubset(actions)


### PR DESCRIPTION
## Summary
- pool Postgres and Redis connections with startup/shutdown lifecycle hooks
- type and lazy-load Next.js home page image
- verify control-plane schema in its actual location

## Testing
- `pytest tests`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b01e7a5c288323bce2f561bd7485f4