### PR TITLE
feat(v13.9): add auth middleware and execution utilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,19 @@ ED25519_PUBKEY=replace_with_pubkey
 REDIS_STREAM_GROUP=angel-group
 REDIS_CONSUMER_NAME=angel-consumer
 
+# Security
+JWT_SECRET=change_me
+IP_ALLOWLIST=127.0.0.1,testclient
+
+# Wallet / execution
+CCXT_API_KEY=replace_with_key
+CCXT_API_SECRET=replace_with_secret
+
+# TLS and CSP
+TLS_CERT_PATH=/etc/nginx/certs/fullchain.pem
+TLS_KEY_PATH=/etc/nginx/certs/privkey.pem
+CSP_POLICY=default-src 'self'; script-src 'self'
+
 # Risk and portfolio
 NAV=1000000
 MAX_DD=0.20

--- a/api/wallet.py
+++ b/api/wallet.py
@@ -1,0 +1,42 @@
+"""CCXT wallet utilities for order execution."""
+
+import os
+from typing import Any, Dict
+
+import ccxt.async_support as ccxt
+
+
+class CCXTWallet:
+    """Thin async wrapper around ccxt exchanges."""
+
+    def __init__(self, exchange: str = "binance") -> None:
+        key = os.getenv("CCXT_API_KEY")
+        secret = os.getenv("CCXT_API_SECRET")
+        self.client = getattr(ccxt, exchange)({
+            "apiKey": key,
+            "secret": secret,
+            "enableRateLimit": True,
+        })
+
+    async def fetch_balance(self) -> Dict[str, Any]:
+        """Fetch account balances."""
+        try:
+            return await self.client.fetch_balance()
+        except ccxt.BaseError as exc:  # pragma: no cover - network errors
+            raise RuntimeError("Balance fetch failed") from exc
+
+    async def create_order(
+        self, symbol: str, side: str, amount: float, price: float | None = None
+    ) -> Dict[str, Any]:
+        """Create an order with basic rate-limit handling."""
+        order_type = "limit" if price is not None else "market"
+        try:
+            return await self.client.create_order(symbol, order_type, side, amount, price)
+        except ccxt.RateLimitExceeded as exc:  # pragma: no cover - depends on exchange load
+            raise RuntimeError("Rate limit exceeded") from exc
+        except ccxt.BaseError as exc:  # pragma: no cover
+            raise RuntimeError("Order failed") from exc
+
+    async def close(self) -> None:
+        """Close underlying exchange client."""
+        await self.client.close()

--- a/app/strategy_manager.py
+++ b/app/strategy_manager.py
@@ -1,0 +1,31 @@
+"""Manage strategy lifecycles and signal aggregation."""
+from __future__ import annotations
+
+from typing import Dict, Protocol
+
+
+class Strategy(Protocol):
+    """Protocol for strategies producing a numeric signal."""
+
+    name: str
+
+    async def evaluate(self, market: dict) -> float:
+        ...
+
+
+class StrategyManager:
+    """Register and run multiple strategies concurrently."""
+
+    def __init__(self) -> None:
+        self._strategies: Dict[str, Strategy] = {}
+
+    def register(self, strategy: Strategy) -> None:
+        """Register a strategy instance."""
+        self._strategies[strategy.name] = strategy
+
+    async def run(self, market: dict) -> Dict[str, float]:
+        """Evaluate all strategies against the provided market snapshot."""
+        results: Dict[str, float] = {}
+        for name, strat in self._strategies.items():
+            results[name] = await strat.evaluate(market)
+        return results

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,0 +1,18 @@
+worker_processes auto;
+
+http {
+    server {
+        listen 443 ssl;
+        server_name _;
+
+        ssl_certificate     $TLS_CERT_PATH;
+        ssl_certificate_key $TLS_KEY_PATH;
+
+        add_header Content-Security-Policy "$CSP_POLICY" always;
+        location / {
+            proxy_pass http://backend:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+}

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: angel-backend
+    static_configs:
+      - targets: ['backend:8000']
+    metrics_path: /metrics

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ PyYAML==6.0.1
 numpy==1.26.4
 pytest==8.4.1
 pytest-asyncio==1.1.0
+PyJWT==2.9.0
+ccxt==4.2.84
 
 optuna==3.6.1
 matplotlib==3.8.2

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,23 @@
+"""Tests for JWT authentication and IP allowlist."""
+import os
+import jwt
+from fastapi.testclient import TestClient
+
+os.environ["JWT_SECRET"] = "secret"
+os.environ["IP_ALLOWLIST"] = "testclient"
+
+import main
+
+client = TestClient(main.app)
+
+def _token() -> str:
+    return jwt.encode({"sub": "tester"}, os.environ["JWT_SECRET"], algorithm="HS256")
+
+def test_authenticated_request() -> None:
+    res = client.get("/secure-ping", headers={"Authorization": f"Bearer {_token()}"})
+    assert res.status_code == 200
+    assert res.json()["status"] == "secure"
+
+def test_missing_token() -> None:
+    res = client.get("/secure-ping")
+    assert res.status_code == 401

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1,0 +1,14 @@
+"""CCXT wallet configuration tests."""
+
+import pytest
+
+from api.wallet import CCXTWallet
+
+
+@pytest.mark.asyncio
+async def test_wallet_initializes(monkeypatch) -> None:
+    monkeypatch.setenv("CCXT_API_KEY", "k")
+    monkeypatch.setenv("CCXT_API_SECRET", "s")
+    wallet = CCXTWallet()
+    assert wallet.client.apiKey == "k"
+    await wallet.close()


### PR DESCRIPTION
## Summary
- add JWT/IP allowlist middleware and secure ping route
- introduce async CCXT wallet wrapper and strategy manager
- provide nginx TLS/CSP and Prometheus scrape configs
- document required secrets in `.env.example`
- cover auth and wallet logic with tests

## Testing
- `pytest -q`
- `npm test` *(partial, watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_68bce061f23083238326a4954b393625