### PR TITLE
feat: add security, wallet, and monitoring components

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,16 @@ AGENT_ID=agent-01
 ED25519_PUBKEY=replace_with_pubkey
 REDIS_STREAM_GROUP=angel-group
 REDIS_CONSUMER_NAME=angel-consumer
+JWT_SECRET=replace_with_strong_secret
+IP_ALLOWLIST=127.0.0.1,192.168.0.0/16
+CCXT_API_KEY=replace_with_key
+CCXT_API_SECRET=replace_with_secret
+CCXT_EXCHANGE=binance
+WEBHOOK_URL=https://example.com/webhook
+OPENAI_API_KEY=replace_with_openai_key
+TLS_CERT_PATH=/etc/nginx/tls/fullchain.pem
+TLS_KEY_PATH=/etc/nginx/tls/privkey.pem
+CSP_POLICY="default-src 'self'; script-src 'self'"
 
 # Risk and portfolio
 NAV=1000000

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 
 from .routers import quantum
+from .security import JWTBearer, allowlist_middleware
 
-app = FastAPI(title="ANGEL.AI Quantum API", version="0.1.0")
+auth = JWTBearer()
+
+app = FastAPI(title="ANGEL.AI Quantum API", version="0.1.0", dependencies=[Depends(auth)])
+app.middleware("http")(allowlist_middleware)
 app.include_router(quantum.router, prefix="/api")
 
 

--- a/api/app/security.py
+++ b/api/app/security.py
@@ -1,0 +1,63 @@
+"""Authentication and network security utilities."""
+from __future__ import annotations
+
+import os
+from ipaddress import ip_address, ip_network
+from typing import List
+
+import jwt
+from fastapi import Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+
+class JWTBearer(HTTPBearer):
+    """Dependency that validates JWT bearer tokens."""
+
+    def __init__(self) -> None:  # noqa: D401 - short and clear
+        super().__init__()
+
+    async def __call__(self, request: Request) -> str:
+        creds: HTTPAuthorizationCredentials | None = await super().__call__(request)
+        if creds is None:
+            raise HTTPException(status_code=403, detail="Missing authorization")
+        try:
+            secret = get_jwt_secret()
+            jwt.decode(creds.credentials, secret, algorithms=["HS256"])
+        except jwt.PyJWTError as exc:  # pragma: no cover - decode raises subclasses
+            raise HTTPException(status_code=403, detail="Invalid token") from exc
+        return creds.credentials
+
+
+def get_jwt_secret() -> str:
+    """Return the JWT secret from the environment."""
+
+    secret = os.getenv("JWT_SECRET")
+    if not secret:
+        raise RuntimeError("JWT_SECRET not configured")
+    return secret
+
+
+def ip_allowlist() -> List[ip_network]:
+    """Parse the IP_ALLOWLIST env var into networks."""
+
+    raw = os.getenv("IP_ALLOWLIST", "")
+    nets: List[ip_network] = []
+    for item in [x.strip() for x in raw.split(",") if x.strip()]:
+        nets.append(ip_network(item, strict=False))
+    return nets
+
+
+async def allowlist_middleware(request: Request, call_next):
+    """Middleware enforcing IP allowlist."""
+
+    client_ip = ip_address(request.client.host)
+    networks = ip_allowlist()
+    if networks and not any(client_ip in net for net in networks):
+        raise HTTPException(status_code=403, detail="IP not allowed")
+    return await call_next(request)
+
+
+def create_jwt(payload: dict) -> str:
+    """Create a signed JWT using the configured secret."""
+
+    return jwt.encode(payload, get_jwt_secret(), algorithm="HS256")

--- a/api/app/wallet/ccxt_wallet.py
+++ b/api/app/wallet/ccxt_wallet.py
@@ -1,0 +1,34 @@
+"""CCXT-powered wallet utilities with basic rate-limit handling."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import ccxt.async_support as ccxt
+
+
+class CCXTWallet:
+    """Interact with an exchange wallet using CCXT."""
+
+    def __init__(self) -> None:
+        exchange_id = os.getenv("CCXT_EXCHANGE", "binance")
+        api_key = os.getenv("CCXT_API_KEY")
+        api_secret = os.getenv("CCXT_API_SECRET")
+        if not api_key or not api_secret:
+            raise RuntimeError("CCXT API credentials not configured")
+        exchange_class = getattr(ccxt, exchange_id)
+        self.exchange = exchange_class({
+            "apiKey": api_key,
+            "secret": api_secret,
+            "enableRateLimit": True,
+        })
+
+    async def balance(self) -> Dict[str, Any]:
+        """Return current wallet balances."""
+
+        return await self.exchange.fetch_balance()
+
+    async def close(self) -> None:
+        """Close underlying connections if any."""
+
+        await self.exchange.close()

--- a/api/app/webhooks.py
+++ b/api/app/webhooks.py
@@ -1,0 +1,18 @@
+"""Webhook dispatch utilities."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import httpx
+
+
+async def post_webhook(payload: Dict[str, Any]) -> None:
+    """Send payload to configured webhook URL."""
+
+    url = os.getenv("WEBHOOK_URL")
+    if not url:
+        raise RuntimeError("WEBHOOK_URL not configured")
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        resp = await client.post(url, json=payload)
+        resp.raise_for_status()

--- a/app/agents/autogpt_optimizer.py
+++ b/app/agents/autogpt_optimizer.py
@@ -1,0 +1,25 @@
+"""AutoGPT-powered strategy refinement helper."""
+from __future__ import annotations
+
+import os
+
+from openai import AsyncOpenAI
+
+
+class AutoGPTOptimizer:
+    """Use OpenAI models to propose strategy improvements."""
+
+    def __init__(self) -> None:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY not configured")
+        self.client = AsyncOpenAI(api_key=api_key)
+
+    async def suggest(self, prompt: str) -> str:
+        """Return a suggestion for the provided prompt."""
+
+        resp = await self.client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message.content or ""

--- a/app/agents/strategy_manager.py
+++ b/app/agents/strategy_manager.py
@@ -1,0 +1,31 @@
+"""Coordinator for multiple trading agents."""
+from __future__ import annotations
+
+import asyncio
+from typing import Dict
+
+from .base import Signal, TradingAgent
+
+
+class StrategyManager:
+    """Manage a collection of trading agents and aggregate their signals."""
+
+    def __init__(self) -> None:
+        self._agents: Dict[str, TradingAgent] = {}
+
+    def register(self, agent: TradingAgent) -> None:
+        """Register an agent for participation."""
+
+        self._agents[agent.agent_id] = agent
+
+    def unregister(self, agent_id: str) -> None:
+        """Remove an agent by identifier."""
+
+        self._agents.pop(agent_id, None)
+
+    async def generate(self) -> Dict[str, Signal]:
+        """Gather signals from all agents concurrently."""
+
+        tasks = [agent.generate_signal() for agent in self._agents.values()]
+        results = await asyncio.gather(*tasks, return_exceptions=False)
+        return {sig.symbol: sig for sig in results}

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,0 +1,13 @@
+server {
+    listen 443 ssl;
+    ssl_certificate ${TLS_CERT_PATH};
+    ssl_certificate_key ${TLS_KEY_PATH};
+
+    add_header Content-Security-Policy ${CSP_POLICY} always;
+
+    location / {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'api'
+    static_configs:
+      - targets: ['api:8000']
+  - job_name: 'node'
+    static_configs:
+      - targets: ['node-exporter:9100']

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,10 @@ PyYAML==6.0.1
 numpy==1.26.4
 pytest==8.4.1
 pytest-asyncio==1.1.0
+PyJWT==2.8.0
+ccxt==4.2.92
+httpx==0.27.0
+openai==1.40.2
 
 optuna==3.6.1
 matplotlib==3.8.2

--- a/tests/test_autogpt_optimizer.py
+++ b/tests/test_autogpt_optimizer.py
@@ -1,0 +1,24 @@
+import pytest
+
+from app.agents.autogpt_optimizer import AutoGPTOptimizer
+
+
+@pytest.mark.asyncio
+async def test_autogpt_suggest(monkeypatch):
+    class DummyCompletions:
+        async def create(self, model, messages):
+            return type(
+                "Resp",
+                (),
+                {"choices": [type("Choice", (), {"message": type("M", (), {"content": "ok"})()})]},
+            )()
+
+    class DummyClient:
+        def __init__(self, api_key: str):
+            self.chat = type("Chat", (), {"completions": DummyCompletions()})()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr("app.agents.autogpt_optimizer.AsyncOpenAI", DummyClient)
+    opt = AutoGPTOptimizer()
+    out = await opt.suggest("hi")
+    assert out == "ok"

--- a/tests/test_ccxt_wallet.py
+++ b/tests/test_ccxt_wallet.py
@@ -1,0 +1,20 @@
+import pytest
+
+from api.app.wallet.ccxt_wallet import CCXTWallet
+
+
+@pytest.mark.asyncio
+async def test_wallet_requires_credentials(monkeypatch):
+    monkeypatch.delenv("CCXT_API_KEY", raising=False)
+    monkeypatch.delenv("CCXT_API_SECRET", raising=False)
+    with pytest.raises(RuntimeError):
+        CCXTWallet()
+
+
+@pytest.mark.asyncio
+async def test_wallet_init(monkeypatch):
+    monkeypatch.setenv("CCXT_API_KEY", "k")
+    monkeypatch.setenv("CCXT_API_SECRET", "s")
+    wallet = CCXTWallet()
+    assert wallet.exchange.apiKey == "k"
+    await wallet.close()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,42 @@
+import pytest
+from fastapi import Request, HTTPException
+
+from api.app.security import (
+    JWTBearer,
+    allowlist_middleware,
+    create_jwt,
+    ip_allowlist,
+)
+
+
+@pytest.mark.asyncio
+async def test_jwt_bearer_valid(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", "secret")
+    token = create_jwt({"sub": "abc"})
+    bearer = JWTBearer()
+    scope = {
+        "type": "http",
+        "headers": [(b"authorization", f"Bearer {token}".encode())],
+        "client": ("127.0.0.1", 1234),
+    }
+    request = Request(scope)
+    assert await bearer(request) == token
+
+
+def test_ip_allowlist(monkeypatch):
+    monkeypatch.setenv("IP_ALLOWLIST", "127.0.0.1,10.0.0.0/24")
+    nets = ip_allowlist()
+    assert len(nets) == 2
+
+
+@pytest.mark.asyncio
+async def test_allowlist_blocks(monkeypatch):
+    monkeypatch.setenv("IP_ALLOWLIST", "10.0.0.0/24")
+    scope = {
+        "type": "http",
+        "client": ("11.1.1.1", 80),
+        "headers": [],
+    }
+    request = Request(scope)
+    with pytest.raises(HTTPException):
+        await allowlist_middleware(request, lambda r: r)

--- a/tests/test_strategy_manager.py
+++ b/tests/test_strategy_manager.py
@@ -1,0 +1,32 @@
+import pytest
+
+from datetime import datetime
+
+from app.agents.admin import AdminAgent
+from app.agents.base import AgentKPI, Signal, TradingAgent
+from app.agents.strategy_manager import StrategyManager
+
+
+class DummyAgent(TradingAgent):
+    async def generate_signal(self) -> Signal:
+        return Signal(
+            schema_version=1,
+            timestamp=datetime.utcnow(),
+            symbol="BTC/USDT",
+            action="BUY",
+            confidence=0.9,
+            size=1.0,
+        )
+
+    async def update_state(self, market_data):  # pragma: no cover - not used
+        self._state.update(market_data)
+
+
+@pytest.mark.asyncio
+async def test_manager_aggregates():
+    admin = AdminAgent()
+    agent = DummyAgent("a", admin, kpi=AgentKPI(1.0, 0.5, 0.1))
+    mgr = StrategyManager()
+    mgr.register(agent)
+    signals = await mgr.generate()
+    assert signals["BTC/USDT"].action == "BUY"

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,20 @@
+import httpx
+import pytest
+
+from api.app.webhooks import post_webhook
+
+
+@pytest.mark.asyncio
+async def test_post_webhook(monkeypatch):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.content == b'{"a": 1}'
+        return httpx.Response(200)
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport)
+
+    monkeypatch.setenv("WEBHOOK_URL", "http://test")
+    monkeypatch.setattr("api.app.webhooks.httpx.AsyncClient", lambda **_: client)
+
+    await post_webhook({"a": 1})
+    await client.aclose()


### PR DESCRIPTION
## Summary
- add JWT auth and IP allowlist middleware
- integrate CCXT wallet and strategy manager
- introduce webhook utilities, AutoGPT optimizer, NGINX TLS config, and Prometheus scrape config

## Testing
- `pytest -q`
- `npx --yes vitest run` *(fails: Cannot find module 'vitest/config')*


------
https://chatgpt.com/codex/tasks/task_e_68bce061f23083238326a4954b393625