### PR TITLE
Add evaluation pipeline for strategy selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 package-lock.json
 
 node_modules
+out/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: bootstrap eval24 decide
+
+bootstrap:
+	pip install -r requirements.txt >/dev/null
+
+eval24:
+	python -m evaluation.runner
+
+decide:
+	python -m evaluation.selector

--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ scripts/rollback.sh
 - `k8s/agent-deployment.yaml`: example Kubernetes deployment
 - `.env.example`: environment template
 - `README.md`: this file
+
+## Strategy Evaluation
+```bash
+make bootstrap
+make eval24
+make decide
+```
+`make eval24` runs a 24-hour backtest with Monte Carlo for each config and `make decide` prints the best setup by profit and drawdown.

--- a/config/eval/supreme_d_run.yaml
+++ b/config/eval/supreme_d_run.yaml
@@ -1,0 +1,5 @@
+name: supreme_d_run
+sizing:
+  base_risk: 0.025
+run:
+  seed: 43

--- a/config/eval/v11_plus.yaml
+++ b/config/eval/v11_plus.yaml
@@ -1,0 +1,5 @@
+name: v11_plus
+sizing:
+  base_risk: 0.015
+run:
+  seed: 41

--- a/config/eval/v13_9_ultracon.yaml
+++ b/config/eval/v13_9_ultracon.yaml
@@ -1,0 +1,5 @@
+name: v13_9_ultracon
+sizing:
+  base_risk: 0.02
+run:
+  seed: 42

--- a/evaluation/__init__.py
+++ b/evaluation/__init__.py
@@ -1,0 +1,5 @@
+"""Evaluation helpers for strategy selection."""
+
+from __future__ import annotations
+
+__all__ = ["runner", "selector"]

--- a/evaluation/runner.py
+++ b/evaluation/runner.py
@@ -1,0 +1,95 @@
+"""Run backtests for multiple configs with Monte Carlo simulation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+import yaml
+
+from api.app.quantum.adaptive import (
+    DynamicThresholdsConfig,
+    FeesConfig,
+    RunConfig,
+    SizingParams,
+    VenueCosts,
+)
+from api.app.quantum.backtester import BacktestEngine
+from api.app.quantum.strategies import (
+    ATRTrendArbConfig,
+    MomentumStacker7Config,
+    QBX3Config,
+    SSv2Config,
+)
+
+CONFIG_DIR = Path("config/eval")
+OUT_FILE = Path("out/eval_results.json")
+MC_RUNS = 10
+
+
+def _load_config(path: Path) -> Dict[str, object]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    sizing = SizingParams(**data.get("sizing", {}))
+    run = RunConfig(**data.get("run", {}))
+    fees = FeesConfig(**data.get("fees", {}))
+    dyn = DynamicThresholdsConfig(**data.get("dyn", {}))
+    return {
+        "name": data.get("name", path.stem),
+        "sizing": sizing,
+        "run": run,
+        "fees": fees,
+        "dyn": dyn,
+    }
+
+
+def _simulate(cfg: Dict[str, object]) -> Dict[str, float]:
+    results: List[Dict[str, float]] = []
+    for i in range(MC_RUNS):
+        seed = cfg["run"].seed + i
+        engine = BacktestEngine(
+            symbol="BTC/USDT",
+            csv_ohlcv_path=None,
+            csv_sentiment_path=None,
+            fees=cfg["fees"],
+            venue_costs=VenueCosts.defaults(),
+            sizing=cfg["sizing"],
+            dyn=cfg["dyn"],
+            run=RunConfig(seed=seed),
+            seed=seed,
+            outdir=Path("out") / f"tmp_{seed}",
+        )
+        df = engine.load_data()
+        params = {
+            "qbx3": QBX3Config(),
+            "ssv2": SSv2Config(),
+            "atra": ATRTrendArbConfig(),
+            "ms7": MomentumStacker7Config(),
+        }
+        res = engine.simulate(df, params)
+        results.append({"pnl": res.pnl, "max_dd": res.max_dd})
+    pnl = float(np.mean([r["pnl"] for r in results]))
+    dd = float(np.mean([r["max_dd"] for r in results]))
+    return {"pnl": pnl, "max_dd": dd}
+
+
+def main() -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    OUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    all_results = {}
+    for path in sorted(CONFIG_DIR.glob("*.yaml")):
+        cfg = _load_config(path)
+        stats = _simulate(cfg)
+        all_results[path.as_posix()] = {
+            "name": cfg["name"],
+            "pnl": stats["pnl"],
+            "max_dd": stats["max_dd"],
+        }
+    OUT_FILE.write_text(json.dumps(all_results, indent=2))
+    print(json.dumps(all_results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluation/selector.py
+++ b/evaluation/selector.py
@@ -1,0 +1,35 @@
+"""Select the best configuration based on backtest metrics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+RESULT_FILE = Path("out/eval_results.json")
+
+
+def choose_config(results: Dict[str, Dict[str, float]]) -> str:
+    """Return path of config with highest PnL and lowest drawdown."""
+    if not results:
+        raise ValueError("no results to choose from")
+    return min(results, key=lambda p: (-results[p]["pnl"], results[p]["max_dd"]))
+
+
+def main() -> None:
+    data = json.loads(RESULT_FILE.read_text())
+    best_path = choose_config(data)
+    best = data[best_path]
+    report_lines = ["Config evaluation results:"]
+    for path, stats in data.items():
+        report_lines.append(
+            f"- {stats['name']}: pnl={stats['pnl']:.4f}, max_dd={stats['max_dd']:.4f}"
+        )
+    report_lines.append(
+        f"\nChosen config: {best['name']} ({best_path}) based on highest pnl and lowest drawdown."
+    )
+    print("\n".join(report_lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_evaluation_pipeline.py
+++ b/tests/test_evaluation_pipeline.py
@@ -1,0 +1,14 @@
+"""Tests for evaluation selector."""
+
+from __future__ import annotations
+
+from evaluation.selector import choose_config
+
+
+def test_choose_config_picks_highest_pnl_lowest_dd() -> None:
+    results = {
+        "a": {"pnl": 0.5, "max_dd": 0.1},
+        "b": {"pnl": 0.6, "max_dd": 0.2},
+        "c": {"pnl": 0.6, "max_dd": 0.15},
+    }
+    assert choose_config(results) == "c"


### PR DESCRIPTION
## Summary
- add Makefile with bootstrap, eval24, decide targets
- implement Monte Carlo backtest runner and config selector
- provide risk-tuned configs and unit test
- document strategy evaluation workflow in README

## Testing
- `make bootstrap`
- `pytest tests/test_evaluation_pipeline.py -q`
- `make eval24`
- `make decide`


------
https://chatgpt.com/codex/tasks/task_e_68bcf0308980832389b6ea3e3b615f40