### PR TITLE
feat: add typed health endpoint and test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ REDIS_STREAM_GROUP=angel-group
 REDIS_CONSUMER_NAME=angel-consumer
 JWT_SECRET=replace_with_strong_secret
 IP_ALLOWLIST=127.0.0.1,192.168.0.0/16
+ADMIN_IPS=10.0.0.5,203.0.113.7
 CCXT_API_KEY=replace_with_key
 CCXT_API_SECRET=replace_with_secret
 CCXT_EXCHANGE=binance
@@ -17,6 +18,7 @@ OPENAI_API_KEY=replace_with_openai_key
 TLS_CERT_PATH=/etc/nginx/tls/fullchain.pem
 TLS_KEY_PATH=/etc/nginx/tls/privkey.pem
 CSP_POLICY="default-src 'self'; script-src 'self'"
+PG_DSN=postgresql://user:pass@pg.example.com:5432/angel
 
 # Risk and portfolio
 NAV=1000000

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap eval24 decide
+.PHONY: bootstrap eval24 decide test
 
 bootstrap:
 	pip install -r requirements.txt >/dev/null
@@ -8,3 +8,6 @@ eval24:
 
 decide:
 	python -m evaluation.selector
+
+test:
+	pytest

--- a/README.md
+++ b/README.md
@@ -51,3 +51,9 @@ make eval24
 make decide
 ```
 `make eval24` runs a 24-hour backtest with Monte Carlo for each config and `make decide` prints the best setup by profit and drawdown.
+
+## Testing
+```bash
+make test
+```
+Run the FastAPI and trading unit tests.

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -1,10 +1,17 @@
 """Health check endpoints."""
 from fastapi import APIRouter
+from pydantic import BaseModel
 
 router = APIRouter(tags=["health"])
 
 
-@router.get("/healthz")
-async def health() -> dict[str, str]:
+class HealthStatus(BaseModel):
+    """Schema for health check responses."""
+
+    status: str
+
+
+@router.get("/healthz", response_model=HealthStatus)
+async def health() -> HealthStatus:
     """Liveness probe returning static status."""
-    return {"status": "ok"}
+    return HealthStatus(status="ok")

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,6 +1,6 @@
 """Application configuration settings using Pydantic BaseSettings."""
 from typing import List, Optional
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -27,8 +27,7 @@ class Settings(BaseSettings):
     okx_key: Optional[str] = None
     okx_secret: Optional[str] = None
 
-    class Config:
-        env_file = ".env"  # development only
+    model_config = SettingsConfigDict(env_file=".env")  # development only
 
 
 settings = Settings()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ openai==1.40.2
 optuna==3.6.1
 matplotlib==3.8.2
 pandas==2.2.2
+pydantic-settings==2.10.1

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,26 @@
+"""Tests for health check endpoint."""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def app(monkeypatch) -> "FastAPI":
+    """Provide FastAPI app with required env vars configured."""
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+    monkeypatch.setenv("PG_DSN", "postgresql://user:pass@localhost:5432/db")
+    module = importlib.import_module("backend.main")
+    importlib.reload(module)
+    return module.app
+
+
+def test_healthz_returns_status_ok(app) -> None:
+    """Health endpoint should return expected status payload."""
+    client = TestClient(app)
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- return typed HealthStatus model from FastAPI /healthz
- switch settings to pydantic-settings and document env vars
- add make test target and unit test for health endpoint

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68c1dd43e5048323b0c472652c2150d6