### PR TITLE
Fix truncated tsconfig to restore TypeScript tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10318,7 +10318,9 @@
       }
     },
     "node_modules/typescript": {
-
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,20 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-
+    "lib": ["dom", "dom.iterable", "esnext"],
     "jsx": "preserve",
     "module": "esnext",
     "moduleResolution": "bundler",
     "strict": true,
     "allowJs": false,
     "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
     "noEmit": true,
+    "esModuleInterop": true,
     "resolveJsonModule": true,
-    "isolatedModules": true,
+    "isolatedModules": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}
+


### PR DESCRIPTION
## Summary
- replace truncated `tsconfig.json` with full Next.js TypeScript config
- update `package-lock.json` to sync dependency versions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c464ace520832387c20127c0839769